### PR TITLE
Fix Github URL declared to Bintray

### DIFF
--- a/mediation/build.gradle
+++ b/mediation/build.gradle
@@ -126,7 +126,7 @@ task generateReleaseSourcesJar(type: Jar) {
 
 def publicationDescription = "Criteo Direct Bidding for App solution with AdMob mediation platform"
 def publicationWebsite = "https://publisherdocs.criteotilt.com/app/android/mediation/admob/"
-def githubUrl = "http://github.com/criteo/android-publisher-sdk-google-adapters"
+def githubUrl = "https://github.com/criteo/android-publisher-sdk-google-adapters"
 
 publishing {
     publications {


### PR DESCRIPTION
Github does not handle HTTP requests. In browser, it is automatically
redirected to HTTPS. But Bintray does not seem to handle the
redirection, the HTTPS link should be provided.

JIRA: EE-1167