### PR TITLE
Improve observability of failing tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,17 @@ jobs:
         run: ./gradlew build assembleAndroidTest --info --stacktrace
 
       - name: Junit Report to Annotations
-        uses: ashley-taylor/junit-report-annotations-action@1.2
-        if: always()
+        uses: ashley-taylor/junit-report-annotations-action@1.3
+        if: failure()
         with:
           access-token: ${{ secrets.GITHUB_TOKEN }}
-          path: "**/TEST-*.xml"
-          testSrcPath: "mediation/src/test/java"
+
+      - name: Upload JUnit report
+        uses: actions/upload-artifact@master
+        if: failure()
+        with:
+          name: junit-report
+          path: "**/build/reports/tests"
 
   android-tests:
     runs-on: macos-latest
@@ -52,8 +57,12 @@ jobs:
           name: logcat
           path: artifacts/logcat.log
 
-      # It is not possible to use the junit-report-annotations-action as for java test.
-      # MacOS will be supported on next version: https://github.com/ashley-taylor/junit-report-annotations-action/issues/8
+      - name: Junit Report to Annotations
+        uses: ashley-taylor/junit-report-annotations-action@1.3
+        if: failure()
+        with:
+          access-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload JUnit report
         uses: actions/upload-artifact@master
         if: failure()


### PR DESCRIPTION
Info and stacktrace options are removed from the gradle build. This
makes the build really really verbose, and finally, it is harder to read
the logs.

Dependency on the junit-report-annotations is upgrade to 1.3:
- MacOS runner is supported
- Multi-module is supported
- Gradle is auto-configured by default
Those annotations brings a high level view on failing tests without
having to dig into the logs or to download the zip of the JUnit reports.

JUnit HTML report is also uploaded in case of failure and help to see
more details than annotations or logs.

Failures are then observable in many ways, from the easiest (but gross)
to the cumbersome (but detailed):
Annotation > Logs > JUnit reports > Logcat (for Android)