### PR TITLE
Fix synchronization of release artifacts on JCenter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         uses: malinskiy/action-android/install-sdk@release/0.0.7
 
       - name: Build & Run Java tests
-        run: ./gradlew build assembleAndroidTest --info --stacktrace
+        run: ./gradlew build assembleAndroidTest
 
       - name: Junit Report to Annotations
         uses: ashley-taylor/junit-report-annotations-action@1.3

--- a/mediation/build.gradle
+++ b/mediation/build.gradle
@@ -131,6 +131,14 @@ def publicationDescription = "Criteo Direct Bidding for App solution with AdMob 
 def publicationWebsite = "https://publisherdocs.criteotilt.com/app/android/mediation/admob/"
 def githubUrl = "https://github.com/criteo/android-publisher-sdk-google-adapters"
 
+def groupId = "com.criteo.mediation.google"
+def artifactId
+if (isSnapshot) {
+    artifactId = "criteo-adapter-development"
+} else {
+    artifactId = "criteo-adapter"
+}
+
 publishing {
     publications {
         release(MavenPublication) {
@@ -140,14 +148,9 @@ publishing {
                 artifact(tasks["generateReleaseJavadocJar"])
             }
 
-            groupId = "com.criteo.mediation.google"
+            it.groupId = groupId
+            it.artifactId = artifactId
             version adapter_publication_version
-
-            if (isSnapshot) {
-                artifactId = "criteo-adapter-development"
-            } else {
-                artifactId = "criteo-adapter"
-            }
 
             pom {
                 withXml {
@@ -196,7 +199,19 @@ bintray {
     pkg {
         repo = "mobile"
         userOrg = "criteo"
-        name = "publisher-sdk-google-adapters"
+
+        // Use different package name for debug and release artifacts:
+        // The synchronization with JCenter was done when only debug artifacts were present. Now,
+        // when release artifacts are pushed in the debug package, they are not synchronized on
+        // JCenter.
+        // It does not seem possible to reset the synchronization. Hence, a new package dedicated
+        // to release artifacts is used.
+        if (isSnapshot) {
+            name = "publisher-sdk-google-adapters"
+        } else {
+            name = "$groupId:$artifactId"
+        }
+
         desc = publicationDescription
         websiteUrl = publicationWebsite
         vcsUrl = githubUrl

--- a/mediation/src/androidTest/java/com/criteo/mediation/google/CriteoNativeAdapterTest.kt
+++ b/mediation/src/androidTest/java/com/criteo/mediation/google/CriteoNativeAdapterTest.kt
@@ -39,7 +39,7 @@ import com.criteo.publisher.mock.MockBean
 import com.criteo.publisher.mock.MockedDependenciesRule
 import com.criteo.publisher.mock.SpyBean
 import com.criteo.publisher.model.AdUnit
-import com.criteo.publisher.model.Slot
+import com.criteo.publisher.model.CdbResponseSlot
 import com.criteo.publisher.model.nativeads.NativeAssets
 import com.criteo.publisher.network.PubSdkApi
 import com.google.android.gms.ads.*
@@ -214,7 +214,7 @@ class CriteoNativeAdapterTest {
     }.whenever(bidManager).getBidForAdUnitAndPrefetch(any())
   }
 
-  private fun Slot.updateAdvertiserLogoWithSupportedImage(): Slot {
+  private fun CdbResponseSlot.updateAdvertiserLogoWithSupportedImage(): CdbResponseSlot {
     // The advertiser logo returned by the stub of CDB is an SVG, which is not supported.
     // To test that the adapter works correctly for the logo, we need to swap it with a supported
     // image. Such as the product one.


### PR DESCRIPTION
Use different package name for debug and release artifacts:
The synchronization with JCenter was done when only debug artifacts were
present. Now, when release artifacts are pushed in the debug package,
they are not synchronized on JCenter.
It does not seem possible to reset the synchronization. Hence, a new
package dedicated to release artifacts is used.

Next step is to ask again the synchronization with JCenter (after first
publishing a version).

JIRA: EE-1234